### PR TITLE
Melhor forma de fazer error handling no login

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5,16 +5,24 @@ import Pagseguro from "./pagseguro.js";
 
 const pagseguro = new Pagseguro(config);
 
-pagseguro.login()
-	.then( logged => {
-		pagseguro.saque()
-			.then( () => {
-				console.log('Saque realizado');
-				process.exit();
-
-			})
-			.catch( () => {
-				console.log('Saque não realizado');
-				process.exit();
-			})
+const sacar = function(provider) {
+	console.log('Verificando saldo');
+	provider
+	.saque()
+	.then( () => {
+		console.log('Saque realizado');
 	})
+	.catch( error => {
+		console.warn('Saque não realizado');
+	})
+}
+
+console.log('Efetuando login')
+pagseguro
+.login()
+.then(sacar)
+.then( process.exit )
+.catch( err => {
+	console.error('Login failed:', err)
+	process.exit()
+})

--- a/src/pagseguro.js
+++ b/src/pagseguro.js
@@ -1,9 +1,9 @@
-let Nightmare = require('nightmare')	
-	, nightmare = Nightmare({
-								show: false
-								, waitTimeout : 45000 // in ms
-								, typeInterval : 700
-						});
+let Nightmare = require('nightmare'),
+	nightmare = Nightmare({
+		show: false,
+		waitTimeout: 45000,
+		typeInterval: 700
+	});
 
 class Pagseguro {
 	constructor(config) {
@@ -12,26 +12,23 @@ class Pagseguro {
 	}
 
 	login(){
-		console.log('Efetuando login')
 		return new Promise((resolve, reject) => {
 			nightmare
 			.goto('https://pagseguro.uol.com.br')
-				.insert('#eml', this.user)
-				.insert('#pwd', this.password)
-				.click('#entrar')
-				.wait('#accountBalance')
-				.then(function(){
-					resolve();
-				})
-				.catch(function (error) {
-					console.error('Login failed:', error);
-					reject('Failed');
-				});
+			.insert('#eml', this.user)
+			.insert('#pwd', this.password)
+			.click('#entrar')
+			.wait('#accountBalance')
+			.then(() => {
+				resolve(this);
+			})
+			.catch( error => {
+				reject(error)
+			});
 		});
 	}
 
 	saque(){
-		console.log('Verificando saldo');
 
 		return new Promise((resolve, reject) => {
 			


### PR DESCRIPTION
Não havia error handling do login: o método login só dava um console.log e rejeitava a promise, mas não tinha um catch. Com isso a aplicação ficava travada.
Coloquei o catch com o console.error dentro dele, aproveitei e tirei uns console.log que ficavam dentro da classe Pagseguro: movi para fora dela, quem faz o consumo dos métodos se encarrega de logar.
Aproveitei e fiz o método login() retornar em caso de sucesso uma instância dele mesmo, aí a função sacar() recebe ele e trata como provider.
No futuro você pode reutilizar essa função 'sacar()' com outros providers.